### PR TITLE
Parent filter

### DIFF
--- a/src/components/Filters/ParentFilter.jsx
+++ b/src/components/Filters/ParentFilter.jsx
@@ -1,0 +1,65 @@
+import React        from 'react'
+import PropTypes    from 'prop-types'
+
+import { Issue }    from 'src/models'
+
+import SelectButton from 'components/SelectButton'
+import BaseFilter   from 'components/Filters/BaseFilter'
+
+
+export default class IssueFilter extends BaseFilter {
+  static CACHE_KEY = 'issue-filter'
+
+  static ALL_ISSUES = { id: '@all',       val: 'All'       }
+
+  static propTypes = {
+    ...BaseFilter.propTypes,
+
+    issues:   PropTypes.arrayOf(PropTypes.instanceOf(Issue)),
+    onChange: PropTypes.func.isRequired,
+  }
+
+  static defaultState = {
+    selectedIssue: IssueFilter.ALL_ISSUES,
+  }
+
+  onChange = (issue) => {
+    this.setState({
+      selectedIssue: issue,
+    }, this.props.onChange)
+  }
+
+  shouldDisplayCard(card) {
+    const issue = Issue.fromIssueElement(card)
+
+    if (!issue) {
+      return false
+    }
+
+    switch (this.state.selectedIssue.id) {
+      case IssueFilter.ALL_ISSUES.id:
+        return true
+
+      default:
+        return issue.id === this.state.selectedIssue.id ||
+          issue.titleTokens.some(token => token.includes(this.state.selectedIssue.issueId))
+    }
+  }
+
+  render() {
+    const issueOptions = [
+      IssueFilter.ALL_ISSUES,
+      ...this.props.issues,
+    ]
+
+    return (
+      <SelectButton
+        className="mr-2"
+        type="Issue"
+        options={issueOptions}
+        onChange={this.onChange}
+        initialSelection={this.state.selectedIssue}
+      />
+    )
+  }
+}

--- a/src/components/Filters/index.js
+++ b/src/components/Filters/index.js
@@ -1,3 +1,4 @@
 export { default as AssigneeFilter } from './AssigneeFilter'
 export { default as FocusFilter    } from './FocusFilter'
 export { default as LabelFilter    } from './LabelFilter'
+export { default as ParentFilter   } from './ParentFilter'

--- a/src/components/ProjectBoardFilters.jsx
+++ b/src/components/ProjectBoardFilters.jsx
@@ -8,6 +8,7 @@ import {
   AssigneeFilter,
   LabelFilter,
   FocusFilter,
+  ParentFilter,
 } from 'components/Filters'
 
 
@@ -26,6 +27,7 @@ export default class ProjectBoardFilters extends React.Component {
     this.state = {
       assignees:     [],
       labels:        [],
+      issues:        [],
       cardFilters:   [],
       columnFilters: [],
     }
@@ -34,6 +36,7 @@ export default class ProjectBoardFilters extends React.Component {
       this.setState({
         assignees: ProjectBoard.assignees,
         labels:    ProjectBoard.labels,
+        issues:    ProjectBoard.issues,
       })
 
       this.renderBoard()
@@ -86,6 +89,12 @@ export default class ProjectBoardFilters extends React.Component {
         />
         <LabelFilter
           labels={this.state.labels}
+          addCardsFilter={this.onCardsFilterAdded}
+          addColumnsFilter={this.onColumnsFilterAdded}
+          onChange={this.onFiltersChanged}
+        />
+        <ParentFilter
+          issues={this.state.issues}
           addCardsFilter={this.onCardsFilterAdded}
           addColumnsFilter={this.onColumnsFilterAdded}
           onChange={this.onFiltersChanged}

--- a/src/lib/ProjectBoard.js
+++ b/src/lib/ProjectBoard.js
@@ -3,7 +3,7 @@ import { isEmpty, uniqBy, sortBy } from 'lodash'
 import GitHubSelectors         from 'src/lib/GitHubSelectors'
 import Storage                 from 'src/lib/Storage'
 
-import { Label, User }         from 'src/models'
+import { Label, User, Issue }         from 'src/models'
 import { memoize, show, hide } from 'src/utils'
 
 /* eslint-disable class-methods-use-this */
@@ -72,6 +72,13 @@ class ProjectBoard {
     labels = sortBy(labels, [label => label.val.toLowerCase()])
 
     return labels
+  }
+
+  get issues() {
+    let issues =  this.cards.map(card => Issue.fromIssueElement(card)).filter(card => card)
+    issues = sortBy(issues, [issue => issue.val.toLowerCase()])
+
+    return issues
   }
 
   async init() {

--- a/src/lib/Session.js
+++ b/src/lib/Session.js
@@ -5,6 +5,7 @@ import {
   Label,
   User,
 } from 'src/models'
+import Issue from '../models/Issue'
 
 
 const Session = {
@@ -21,6 +22,8 @@ const Session = {
           return new Label(val)
         case User.CACHE_KEY:
           return new User(val)
+        case Issue.CACHE_KEY:
+          return new Issue(val)
 
         default:
           throw new Error(`Don’t know how to deserialize ${val[BaseModel.SERIALIZE_KEY]}`)

--- a/src/models/Issue.js
+++ b/src/models/Issue.js
@@ -1,0 +1,32 @@
+import BaseModel from './BaseModel'
+
+export default class Issue extends BaseModel {
+  static CACHE_KEY = 'issue'
+
+  static fromIssueElement = (issue) => {
+    const type = JSON.parse(issue.dataset.cardType)[0]
+
+    if (type !== 'issue') {
+      return null
+    }
+
+    const repo = JSON.parse(issue.dataset.cardRepo)[0]
+    const titleData = JSON.parse(issue.dataset.cardTitle)
+    const issueId = Number(titleData[titleData.length - 2])
+    return new Issue({
+      repo,
+      issueId,
+      titleTokens: titleData,
+    })
+  }
+
+  constructor({ repo, issueId, titleTokens }) {
+    super()
+
+    this.repo = repo
+    this.issueId   = issueId
+    this.titleTokens = titleTokens
+    this.id = `${repo}-${issueId}`
+    this.val = `${repo} ${issueId}`
+  }
+}

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,3 +1,4 @@
 export { default as BaseModel } from './BaseModel'
 export { default as Label     } from './Label'
 export { default as User      } from './User'
+export { default as Issue     } from './Issue'

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,3 +9,5 @@ export {
   fooLabel,
   barLabel,
 } from './labels'
+
+export { default as fooIssue } from './issues'

--- a/test/fixtures/issues.js
+++ b/test/fixtures/issues.js
@@ -1,0 +1,7 @@
+import Issue from 'src/models/Issue'
+
+export default new Issue({
+  repo: 'org/repo',
+  issueId: 1234,
+  titleTokens: ['title'],
+})

--- a/test/lib/Session.test.js
+++ b/test/lib/Session.test.js
@@ -1,11 +1,12 @@
 import App     from 'src/lib/App'
 import Session from 'src/lib/Session'
 
-import { fooLabel, cachedUser } from 'test/fixtures'
+import { fooLabel, cachedUser, fooIssue } from 'test/fixtures'
 
 import {
   Label,
   User,
+  Issue,
 } from 'src/models'
 
 describe('Session', () => {
@@ -54,6 +55,20 @@ describe('Session', () => {
         Object.entries(hydratedLabel).toString(),
       ).toEqual(
         Object.entries(fooLabel).toString(),
+      )
+    })
+
+    it('returns hydrated Issues', () => {
+      const hydratedIssue = Session.deserialize(JSON.stringify({
+        __constructor__: fooIssue.CACHE_KEY,
+        ...fooIssue,
+      }))
+
+      expect(hydratedIssue).toBeInstanceOf(Issue)
+      expect(
+        Object.entries(hydratedIssue).toString(),
+      ).toEqual(
+        Object.entries(fooIssue).toString(),
       )
     })
 

--- a/test/models/Issue.test.js
+++ b/test/models/Issue.test.js
@@ -1,0 +1,40 @@
+import { oneLine } from 'common-tags'
+
+import { Issue } from 'src/models'
+import { stringToDOM } from 'src/utils'
+
+describe('Issue', () => {
+  describe('.fromIssueElement()', () => {
+    it('creates a new Issue from an issue element', () => {
+      const issueElement = stringToDOM(oneLine`
+        <article 
+          class="issue-card project-card position-relative rounded-2 box-shadow bg-white my-2 mx-0 border ws-normal js-project-column-card js-socket-channel js-updatable-content draggable js-keyboard-movable"
+          data-card-repo="[&quot;org/repo&quot;]" 
+          data-card-title="[&quot;title&quot;,&quot;1234&quot;,&quot;#1234&quot;]"
+          data-card-type="[&quot;issue&quot;]">
+        </article>
+      `)
+
+      const issue = Issue.fromIssueElement(issueElement)
+
+      expect(issue.repo).toBe('org/repo')
+      expect(issue.issueId).toBe(1234)
+      expect(issue.titleTokens).toStrictEqual(['title', '1234', '#1234'])
+      expect(issue.id).toBe('org/repo-1234')
+      expect(issue.val).toBe('org/repo 1234')
+    })
+
+    it('returns null from a note element', () => {
+      const issueElement = stringToDOM(oneLine`
+        <article 
+          class="issue-card project-card position-relative rounded-2 box-shadow bg-white my-2 mx-0 border ws-normal js-project-column-card js-socket-channel js-updatable-content draggable js-keyboard-movable"
+          data-card-type="[&quot;note&quot;]"
+        </article>
+      `)
+
+      const issue = Issue.fromIssueElement(issueElement)
+
+      expect(issue).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
Adds a filter to show a parent issue and all associated child issues. A child issue is defined as any issue that contains the parent issue ID in its title. 

#### Note: 
This filter currently doesn't differentiate between repos. Thus there's the possibility that a child issue points to a parent that shares an ID with another issue on the board, but from a different repo. Patches welcome!